### PR TITLE
Fix flask backend integration tests

### DIFF
--- a/alternatives/server-flask/requirements-dev.in
+++ b/alternatives/server-flask/requirements-dev.in
@@ -3,3 +3,4 @@
 flake8
 mypy
 pytest
+requests

--- a/alternatives/server-flask/requirements-dev.txt
+++ b/alternatives/server-flask/requirements-dev.txt
@@ -9,12 +9,14 @@ attrs==19.1.0             # via packaging, pytest
 blinker==1.4              # via sentry-sdk
 boto3==1.9.220
 botocore==1.12.220        # via boto3, s3transfer
-certifi==2019.6.16        # via sentry-sdk
+certifi==2019.6.16        # via requests, sentry-sdk
+chardet==3.0.4            # via requests
 click==7.0                # via flask
 docutils==0.15.2          # via botocore
 entrypoints==0.3          # via flake8
 flake8==3.7.8
 flask==1.1.1
+idna==2.8                 # via requests
 importlib-metadata==0.19  # via pluggy, pytest
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
@@ -35,12 +37,13 @@ pyparsing==2.4.2          # via packaging
 pytest==5.1.1
 python-dateutil==2.8.0    # via botocore
 python-json-logger==0.1.11
+requests==2.22.0
 s3transfer==0.2.1         # via boto3
 sentry-sdk[flask]==0.11.2
 six==1.12.0               # via packaging, python-dateutil
 typed-ast==1.4.0          # via mypy
 typing-extensions==3.7.4  # via mypy
-urllib3==1.25.3           # via botocore, sentry-sdk
+urllib3==1.25.3           # via botocore, requests, sentry-sdk
 wcwidth==0.1.7            # via pytest
 werkzeug==0.15.5          # via flask
 zipp==0.6.0               # via importlib-metadata

--- a/alternatives/server-flask/src/config.py
+++ b/alternatives/server-flask/src/config.py
@@ -68,7 +68,3 @@ class Config:
 
     # Testing
     TESTING = False
-
-
-class TestConfig(Config):
-    TESTING = True

--- a/alternatives/server-flask/src/log.py
+++ b/alternatives/server-flask/src/log.py
@@ -14,8 +14,10 @@ no_log_paths: typing.Set[str] = {'/healthz', '/uptimez'}
 def setup(app: Flask) -> None:
     try:
         app.logger.setLevel(app.config['COMMON_LOG_LEVEL'])
-    except ValueError:
-        # Invalid loglevel. Leave as default.
+    except (TypeError, ValueError):
+        # TypeError: Invalid loglevel (e.g. None)
+        # ValueError: Unknown loglevel
+        # Leave as default.
         pass
 
     # Setup request/response logging

--- a/alternatives/server-flask/test/conftest.py
+++ b/alternatives/server-flask/test/conftest.py
@@ -1,14 +1,37 @@
+import os
 import pytest
-from src import create_app
-from src.config import TestConfig
+import requests
+from urllib.parse import urljoin
 
 
-@pytest.fixture
-def app():
-    app = create_app(TestConfig)
-    yield app
+@pytest.yield_fixture
+def client():
+    with BaseUrlSession() as session:
+        yield session
 
 
-@pytest.fixture
-def client(app):
-    return app.test_client()
+class BaseUrlSession(requests.Session):
+    """Url-prefixed requests.Session class.
+
+    Based on requests_toolbelt.sessions.BaseUrlSession.
+    """
+
+    base_url = os.environ['TEST_API_URL']
+
+    def __init__(self):
+        super().__init__()
+        if not self.base_url.endswith('/'):
+            # urljoin is pretty exact about the slash use
+            self.base_url = f'{self.base_url}/'
+
+    def request(self, method, url, *args, **kwargs):
+        """Send the request after generating the complete URL."""
+        url = self.create_url(url)
+        return super().request(method, url, *args, **kwargs)
+
+    def create_url(self, url):
+        """Create the URL based off this partial path."""
+        if url.startswith('/'):
+            # urljoin is pretty exact about the slash use
+            url = url[1:]
+        return urljoin(self.base_url, url)

--- a/alternatives/server-flask/test/test_factory.py
+++ b/alternatives/server-flask/test/test_factory.py
@@ -1,7 +1,0 @@
-from src import create_app
-from src.config import TestConfig
-
-
-def test_config():
-    assert not create_app().testing
-    assert create_app(TestConfig).testing

--- a/alternatives/server-flask/test/test_infra.py
+++ b/alternatives/server-flask/test/test_infra.py
@@ -1,16 +1,12 @@
-from src.config import TestConfig
-
-
 def test_get_config(client):
     response = client.get('/config')
     assert response.status_code == 200
-    assert response.mimetype == 'application/json'
-    config = response.get_json()
+    assert response.headers['Content-Type'] == 'application/json'
+    config = response.json()
     assert type(config) is dict
     assert 'data' in config
     assert type(config['data']) is dict
     assert 'APP_VERSION' in config['data']
-    assert config['data']['APP_VERSION'] == TestConfig.APP_VERSION
 
 
 def test_get_uptimez(client):

--- a/alternatives/server-flask/test/test_posts.py
+++ b/alternatives/server-flask/test/test_posts.py
@@ -1,8 +1,8 @@
 def test_get_posts(client):
     response = client.get('/posts')
     assert response.status_code == 200
-    assert response.mimetype == 'application/json'
-    data = response.get_json()
+    assert response.headers['Content-Type'] == 'application/json'
+    data = response.json()
     assert type(data) is dict
     assert 'data' in data
     assert type(data['data']) is list


### PR DESCRIPTION
Instead of running the tests against locally running server, run the tests against a remote API.

Fixes #93