### PR TITLE
fix: empty taito_mode throws an error on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "if [ '$taito_mode' != 'ci' ]; then npm run precommit:branch && npm run precommit:lint; fi",
-      "pre-push": "if [ '$taito_mode' != 'ci' ]; then npm-run-all --parallel lint unit; fi"
+      "pre-commit": "if [ \"$taito_mode\" != 'ci' ]; then npm run precommit:branch && npm run precommit:lint; fi",
+      "pre-push": "if [ \"$taito_mode\" != 'ci' ]; then npm-run-all --parallel lint unit; fi"
     }
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "if [ $taito_mode != 'ci' ]; then npm run precommit:branch && npm run precommit:lint; fi",
-      "pre-push": "if [ $taito_mode != 'ci' ]; then npm-run-all --parallel lint unit; fi"
+      "pre-commit": "if [ '$taito_mode' != 'ci' ]; then npm run precommit:branch && npm run precommit:lint; fi",
+      "pre-push": "if [ '$taito_mode' != 'ci' ]; then npm-run-all --parallel lint unit; fi"
     }
   },
   "commitlint": {


### PR DESCRIPTION
The pre-commit (and pre-push) hooks throw
```
husky > pre-commit (node v15.5.1)
sh: line 1: [: !=: unary operator expected
```
when `$taito_mode` is not set.

bash version 5.1.4