### PR TITLE
Persist apollo cache and improve preloading

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9545,6 +9545,11 @@
         }
       }
     },
+    "apollo3-cache-persist": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.12.1.tgz",
+      "integrity": "sha512-bYh/OzhzR70URRRf0OkzkpTLB7+fwx1Ftiw8/MWW8NhEgF+K9u3FO786DSUcE6X2NqSObYKF0+CpM9K8vrJNxw=="
+    },
     "app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@lingui/react": "3.10.2",
     "@loadable/component": "5.15.0",
     "@sentry/browser": "6.12.0",
+    "apollo3-cache-persist": "0.12.1",
     "axios": "0.21.3",
     "date-fns": "2.23.0",
     "framer-motion": "4.1.17",

--- a/client/src/Providers.tsx
+++ b/client/src/Providers.tsx
@@ -1,27 +1,23 @@
 import type { ReactNode } from 'react';
 import { OverlayProvider } from 'react-aria';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { ApolloProvider } from '@apollo/client';
 
 import Toaster from '~components/common/Toaster';
 import { ThemingProvider } from '~services/theming';
 import { I18nProvider } from '~services/i18n';
 import { AuthProvider } from '~services/auth';
-import { apolloClient } from '~graphql';
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (
-    <ApolloProvider client={apolloClient}>
-      <ThemingProvider>
-        <AuthProvider>
-          <I18nProvider>
-            <OverlayProvider>
-              <Router>{children}</Router>
-            </OverlayProvider>
-            <Toaster />
-          </I18nProvider>
-        </AuthProvider>
-      </ThemingProvider>
-    </ApolloProvider>
+    <ThemingProvider>
+      <AuthProvider>
+        <I18nProvider>
+          <OverlayProvider>
+            <Router>{children}</Router>
+          </OverlayProvider>
+          <Toaster />
+        </I18nProvider>
+      </AuthProvider>
+    </ThemingProvider>
   );
 }

--- a/client/src/components/navigation/Link.tsx
+++ b/client/src/components/navigation/Link.tsx
@@ -14,12 +14,11 @@ import { routes } from '../../routes';
 
 type Props = LinkProps & {
   children: ReactNode;
-  preloadMethod?: 'hover' | 'click';
 };
 
 export const Link = forwardRef<any, Props>(
-  ({ children, to, preloadMethod, ...props }, ref: any) => {
-    const p = useLinkProps(to, preloadMethod);
+  ({ children, to, ...props }, ref: any) => {
+    const p = useLinkProps(to);
 
     return (
       <FocusRing focusRingClass="link-focus">
@@ -34,8 +33,8 @@ export const Link = forwardRef<any, Props>(
 Link.displayName = 'Link';
 
 export const UnstyledLink = forwardRef<any, Props>(
-  ({ children, to, preloadMethod, ...props }, ref: any) => {
-    const p = useLinkProps(to, preloadMethod);
+  ({ children, to, ...props }, ref: any) => {
+    const p = useLinkProps(to);
 
     return (
       <UnstyledLinkWrapper {...props} {...p} to={to} ref={ref}>
@@ -49,8 +48,8 @@ UnstyledLink.displayName = 'UnstyledLink';
 
 // Nav link knows whether it is active or not based on the current url
 export const NavLink = forwardRef<any, Props>(
-  ({ children, to, preloadMethod, ...props }, ref: any) => {
-    const p = useLinkProps(to, preloadMethod);
+  ({ children, to, ...props }, ref: any) => {
+    const p = useLinkProps(to);
 
     return (
       <FocusRing focusRingClass="link-focus">
@@ -64,10 +63,7 @@ export const NavLink = forwardRef<any, Props>(
 
 NavLink.displayName = 'NavLink';
 
-function useLinkProps(
-  to: Props['to'],
-  preloadMethod: Props['preloadMethod'] = 'hover'
-) {
+function useLinkProps(to: Props['to']) {
   const isStale = useStaleReload();
 
   function handleStaleNavigation() {
@@ -76,7 +72,7 @@ function useLinkProps(
   }
 
   // Preload route code for faster page load experience
-  async function handlePreload() {
+  async function handlePreload(trigger: 'click' | 'hover') {
     const match = ({ path }: any) => {
       // Remove search params
       const [_to] = to.toString().split('?');
@@ -94,7 +90,7 @@ function useLinkProps(
 
     if (route?.component && route.component.preload) {
       try {
-        await route.component.preload(match(route)?.params);
+        await route.component.preload(match(route)?.params || null, trigger);
       } catch (error) {
         console.log('> Failed to preload route', error);
       }
@@ -104,10 +100,10 @@ function useLinkProps(
   return useMemo(
     () => ({
       onClick: handleStaleNavigation,
-      onMouseEnter: preloadMethod === 'hover' ? handlePreload : undefined,
-      onMouseDown: preloadMethod === 'click' ? handlePreload : undefined,
+      onMouseEnter: () => handlePreload('hover'),
+      onMouseDown: () => handlePreload('click'),
     }),
-    [to, preloadMethod] // eslint-disable-line
+    [to] // eslint-disable-line
   );
 }
 

--- a/client/src/graphql/client.ts
+++ b/client/src/graphql/client.ts
@@ -1,11 +1,86 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { LocalStorageWrapper, CachePersistor } from 'apollo3-cache-persist';
+
+import {
+  ApolloClient,
+  InMemoryCache,
+  DefaultOptions,
+  NormalizedCacheObject,
+} from '@apollo/client';
+
 import config from '~constants/config';
 
-export const apolloClient = new ApolloClient({
-  uri: config.API_URL,
-  cache: new InMemoryCache(),
-  defaultOptions: {
-    query: { fetchPolicy: 'cache-first' },
-    watchQuery: { fetchPolicy: 'cache-and-network' },
+const defaultOptions: DefaultOptions = {
+  query: { fetchPolicy: 'cache-first' },
+  // Use Stale-While-Revalidate pattern to keep data fresh even when it's read from cache
+  watchQuery: {
+    fetchPolicy: 'cache-and-network',
+    // Avoid infinite loops
+    // https://github.com/apollographql/apollo-client/issues/6760#issuecomment-668188727
+    nextFetchPolicy: 'cache-first',
   },
-});
+};
+
+const cache = new InMemoryCache();
+
+// This is used for preloading data outside of React
+let __client__: ApolloClient<NormalizedCacheObject>;
+
+export async function setupApolloClient() {
+  const persistor = new CachePersistor({
+    cache,
+    storage: new LocalStorageWrapper(window.localStorage),
+  });
+
+  const shouldPurge = await shouldPurgeStorage();
+
+  if (shouldPurge) {
+    await persistor.purge();
+  } else {
+    await persistor.restore();
+  }
+
+  const client = new ApolloClient({
+    uri: config.API_URL,
+    cache,
+    defaultOptions,
+  });
+
+  __client__ = client;
+
+  return client;
+}
+
+export function getApolloClient() {
+  return __client__;
+}
+
+type ClientQueryParams = Parameters<
+  ApolloClient<NormalizedCacheObject>['query']
+>[0];
+
+export function preloadQuery(
+  query: ClientQueryParams['query'],
+  variables?: ClientQueryParams['variables']
+) {
+  return __client__.query({ query, variables, fetchPolicy: 'network-only' });
+}
+
+export type PreloadHandler = (
+  params: null | Record<string, any>,
+  trigger: 'click' | 'hover'
+) => Promise<void>;
+
+// https://github.com/apollographql/apollo-cache-persist/blob/master/docs/faq.md#ive-had-a-breaking-schema-change-how-do-i-migrate-or-purge-my-cache
+const SCHEMA_VERSION = '1';
+const SCHEMA_VERSION_KEY = 'apollo-schema-version';
+
+async function shouldPurgeStorage() {
+  const currentVersion = localStorage.getItem(SCHEMA_VERSION_KEY);
+
+  if (currentVersion === SCHEMA_VERSION) {
+    return false;
+  } else {
+    localStorage.setItem(SCHEMA_VERSION_KEY, SCHEMA_VERSION);
+    return true;
+  }
+}

--- a/client/src/graphql/client.ts
+++ b/client/src/graphql/client.ts
@@ -3,22 +3,10 @@ import { LocalStorageWrapper, CachePersistor } from 'apollo3-cache-persist';
 import {
   ApolloClient,
   InMemoryCache,
-  DefaultOptions,
   NormalizedCacheObject,
 } from '@apollo/client';
 
 import config from '~constants/config';
-
-const defaultOptions: DefaultOptions = {
-  query: { fetchPolicy: 'cache-first' },
-  // Use Stale-While-Revalidate pattern to keep data fresh even when it's read from cache
-  watchQuery: {
-    fetchPolicy: 'cache-and-network',
-    // Avoid infinite loops
-    // https://github.com/apollographql/apollo-client/issues/6760#issuecomment-668188727
-    nextFetchPolicy: 'cache-first',
-  },
-};
 
 const cache = new InMemoryCache();
 
@@ -42,7 +30,11 @@ export async function setupApolloClient() {
   const client = new ApolloClient({
     uri: config.API_URL,
     cache,
-    defaultOptions,
+    defaultOptions: {
+      query: {
+        fetchPolicy: 'cache-first',
+      },
+    },
   });
 
   __client__ = client;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,14 +1,27 @@
 import './index.css';
 
 import ReactDOM from 'react-dom';
+import { ApolloProvider } from '@apollo/client';
 
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { setupErrorReporting } from '~services/reporting';
+import { setupApolloClient } from '~graphql';
 
-setupErrorReporting();
+async function init() {
+  setupErrorReporting();
 
-ReactDOM.render(<App />, document.getElementById('app'));
+  const apolloClient = await setupApolloClient();
+
+  ReactDOM.render(
+    <ApolloProvider client={apolloClient}>
+      <App />
+    </ApolloProvider>,
+    document.getElementById('app')
+  );
+}
+
+init();
 
 // NOTE: Service Worker is enabled only in production builds
 // NOTE: check `serviceWorker.ts` if you want to use automatic app update propmt

--- a/client/src/routes/home/index.tsx
+++ b/client/src/routes/home/index.tsx
@@ -3,6 +3,7 @@ import { t } from '@lingui/macro';
 import HomePlaceholder from './HomePlaceholder';
 import { loadableWithFallback } from '~utils/promise';
 import { useDocumentTitle } from '~utils/routing';
+import { PreloadHandler } from '~graphql';
 
 const Home = loadableWithFallback(() => import('./Home'), <HomePlaceholder />);
 
@@ -12,7 +13,6 @@ export default function HomeContainer() {
   return <Home />;
 }
 
-// Preload component and data
-HomeContainer.preload = async () => {
+HomeContainer.preload = (async () => {
   Home.preload();
-};
+}) as PreloadHandler;

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -11,6 +11,7 @@ import Theming from './theming';
 import Page from '~components/navigation/Page';
 import ProtectedRoute from '~components/navigation/ProtectedRoute';
 import { useAuthCheck } from '~services/auth';
+import { PreloadHandler } from '~graphql';
 
 const Main = loadable(() => import('./Main'));
 const Login = loadable(() => import('./login'));
@@ -19,9 +20,7 @@ const NotFoundAuthenticated = loadable(
   () => import('./not-found/index.authenticated')
 );
 
-type ContainerPage = (() => JSX.Element) & {
-  preload?: (params?: Record<string, any>) => Promise<void>;
-};
+type ContainerPage = (() => JSX.Element) & { preload?: PreloadHandler };
 
 type Route = {
   path: string;

--- a/client/src/routes/post-create/index.tsx
+++ b/client/src/routes/post-create/index.tsx
@@ -3,6 +3,7 @@ import { t } from '@lingui/macro';
 import PostCreatePlaceholder from './PostCreatePlaceholder';
 import { loadableWithFallback } from '~utils/promise';
 import { useDocumentTitle } from '~utils/routing';
+import { PreloadHandler } from '~graphql';
 
 const PostCreate = loadableWithFallback(
   () => import('./PostCreate'),
@@ -15,7 +16,6 @@ export default function PostCreateContainer() {
   return <PostCreate />;
 }
 
-// Preload component and data
-PostCreateContainer.preload = async () => {
-  await PostCreate.preload();
-};
+PostCreateContainer.preload = (async () => {
+  PostCreate.preload();
+}) as PreloadHandler;

--- a/client/src/routes/post-list/PostList.tsx
+++ b/client/src/routes/post-list/PostList.tsx
@@ -32,7 +32,7 @@ export default function PostListPage({ postListQuery }: Props) {
         <Stack as="ul" axis="y" spacing="normal">
           {posts.map(post => (
             <li key={post.id}>
-              <UnstyledLink to={post.id} preloadMethod="click">
+              <UnstyledLink to={post.id}>
                 <PostListCard
                   createdAt={post.createdAt}
                   subject={post.subject}

--- a/client/src/routes/post-list/index.tsx
+++ b/client/src/routes/post-list/index.tsx
@@ -4,7 +4,13 @@ import type { Props as PostListProps } from './PostList';
 import PostListPlaceholder from './PostListPlaceholder';
 import { loadableWithFallback } from '~utils/promise';
 import { useDocumentTitle } from '~utils/routing';
-import { apolloClient, PostListDocument, usePostListQuery } from '~graphql';
+
+import {
+  preloadQuery,
+  PreloadHandler,
+  PostListDocument,
+  usePostListQuery,
+} from '~graphql';
 
 const PostList = loadableWithFallback<PostListProps>(
   () => import('./PostList'),
@@ -19,8 +25,10 @@ export default function PostListContainer() {
   return <PostList postListQuery={postListQuery} />;
 }
 
-// Preload component and data
-PostListContainer.preload = async () => {
+PostListContainer.preload = (async (_, trigger) => {
   PostList.preload();
-  await apolloClient.query({ query: PostListDocument });
-};
+
+  if (trigger === 'click') {
+    await preloadQuery(PostListDocument);
+  }
+}) as PreloadHandler;

--- a/client/src/routes/post/index.tsx
+++ b/client/src/routes/post/index.tsx
@@ -5,7 +5,12 @@ import PostPlaceholder from './PostPlaceholder';
 import Breadcrumbs from '~components/navigation/Breadcrumbs';
 import { loadableWithFallback } from '~utils/promise';
 import { useDocumentTitle } from '~utils/routing';
-import { apolloClient, usePostQuery, PostDocument } from '~graphql';
+import {
+  preloadQuery,
+  usePostQuery,
+  PostDocument,
+  PreloadHandler,
+} from '~graphql';
 
 const Post = loadableWithFallback<PostParams>(
   () => import('./Post'),
@@ -32,11 +37,10 @@ export default function PostContainer() {
 }
 
 // Preload component and data
-PostContainer.preload = async (params: Record<string, any>) => {
+PostContainer.preload = (async (params, trigger) => {
   Post.preload();
 
-  await apolloClient.query({
-    query: PostDocument,
-    variables: { id: params.id },
-  });
-};
+  if (trigger === 'click') {
+    await preloadQuery(PostDocument, { id: params?.id });
+  }
+}) as PreloadHandler;

--- a/client/src/routes/theming/index.tsx
+++ b/client/src/routes/theming/index.tsx
@@ -3,6 +3,7 @@ import { t } from '@lingui/macro';
 import ThemingPlaceholder from './ThemingPlaceholder';
 import { loadableWithFallback } from '~utils/promise';
 import { useDocumentTitle } from '~utils/routing';
+import { PreloadHandler } from '~graphql';
 
 const Theming = loadableWithFallback(
   () => import('./Theming'),
@@ -15,7 +16,6 @@ export default function ThemingContainer() {
   return <Theming />;
 }
 
-// Preload component and data
-ThemingContainer.preload = async () => {
+ThemingContainer.preload = (async () => {
   Theming.preload();
-};
+}) as PreloadHandler;

--- a/client/src/services/auth.tsx
+++ b/client/src/services/auth.tsx
@@ -6,7 +6,7 @@ import {
   ReactNode,
 } from 'react';
 
-import { apolloClient } from '~graphql';
+import { getApolloClient } from '~graphql';
 import { hideSplashScreen } from '~utils/splash';
 import { sleep } from '~utils/promise';
 import storage from '~utils/storage';
@@ -56,7 +56,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       // Logout the user even if the network call failed
       setStatus('unauthenticated');
+
+      const apolloClient = getApolloClient();
       await apolloClient.resetStore();
+
       storage.clearAll();
     }
   }


### PR DESCRIPTION
- By persisting the Apollo cache and restoring it when the app starts we can get a much snappier feeling UX.
- Fetching data can be an expensive operation on our server so the route preloading was improved by only preloading queries when the user actually clicks a link. Code-split route components are still preloaded eagerly on link hover.