### PR TITLE
Feat/react aria components

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "4.17.21",
         "react": "18.2.0",
         "react-aria": "3.24.0",
+        "react-aria-components": "1.0.0-alpha.4",
         "react-dom": "18.2.0",
         "react-hot-toast": "2.4.0",
         "react-icons": "4.8.0",
@@ -5649,6 +5650,26 @@
         "@react-stately/tabs": "^3.4.1",
         "@react-types/shared": "^3.18.1",
         "@react-types/tabs": "^3.3.0",
+        "@swc/helpers": "^0.4.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.0.0.tgz",
+      "integrity": "sha512-UuYqlysitwv1e1SV9YJqUMV7P7Gg5triEljyJ90b4rtETRhGa+Qh6cVa1P8F4h5nPTwzqey47jAp45i1FSsH4w==",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.4.0",
+        "@react-aria/i18n": "^3.7.2",
+        "@react-aria/interactions": "^3.15.1",
+        "@react-aria/label": "^3.5.2",
+        "@react-aria/selection": "^3.15.0",
+        "@react-aria/utils": "^3.17.0",
+        "@react-stately/list": "^3.8.1",
+        "@react-types/button": "^3.7.3",
+        "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.4.14"
       },
       "peerDependencies": {
@@ -20062,6 +20083,107 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/react-aria-components": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-cv8+mF5AykoOH0nV2gkQqzJSz7Cqfv5p2kVup2HCRM5CSeourC69d6mKI5htka4XYcrw9E4G0KtRqQnc9/J4DA==",
+      "dependencies": {
+        "@internationalized/date": "^3.2.0",
+        "@react-aria/focus": "^3.12.1",
+        "@react-aria/utils": "^3.17.0",
+        "@react-stately/table": "^3.9.1",
+        "@react-types/grid": "^3.1.8",
+        "@react-types/shared": "^3.18.1",
+        "@react-types/table": "^3.6.1",
+        "@swc/helpers": "^0.4.14",
+        "react-aria": "^3.25.0",
+        "react-stately": "^3.23.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/react-aria-components/node_modules/react-aria": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.25.0.tgz",
+      "integrity": "sha512-nvahN6tUCnES9CXCKEzEHkWy7mH39KsQoCk6eehIT3eG1pw/eYUqXFAmmWIL3g2VDCiGavpSf1/BUTnAXE2VsQ==",
+      "dependencies": {
+        "@react-aria/breadcrumbs": "^3.5.2",
+        "@react-aria/button": "^3.7.2",
+        "@react-aria/calendar": "^3.3.0",
+        "@react-aria/checkbox": "^3.9.1",
+        "@react-aria/combobox": "^3.6.1",
+        "@react-aria/datepicker": "^3.4.1",
+        "@react-aria/dialog": "^3.5.2",
+        "@react-aria/dnd": "^3.2.1",
+        "@react-aria/focus": "^3.12.1",
+        "@react-aria/gridlist": "^3.4.0",
+        "@react-aria/i18n": "^3.7.2",
+        "@react-aria/interactions": "^3.15.1",
+        "@react-aria/label": "^3.5.2",
+        "@react-aria/link": "^3.5.1",
+        "@react-aria/listbox": "^3.9.1",
+        "@react-aria/menu": "^3.9.1",
+        "@react-aria/meter": "^3.4.2",
+        "@react-aria/numberfield": "^3.5.1",
+        "@react-aria/overlays": "^3.14.1",
+        "@react-aria/progress": "^3.4.2",
+        "@react-aria/radio": "^3.6.1",
+        "@react-aria/searchfield": "^3.5.2",
+        "@react-aria/select": "^3.10.1",
+        "@react-aria/selection": "^3.15.0",
+        "@react-aria/separator": "^3.3.2",
+        "@react-aria/slider": "^3.4.1",
+        "@react-aria/ssr": "^3.6.0",
+        "@react-aria/switch": "^3.5.1",
+        "@react-aria/table": "^3.9.1",
+        "@react-aria/tabs": "^3.6.0",
+        "@react-aria/tag": "^3.0.0",
+        "@react-aria/textfield": "^3.9.2",
+        "@react-aria/tooltip": "^3.5.1",
+        "@react-aria/utils": "^3.17.0",
+        "@react-aria/visually-hidden": "^3.8.1",
+        "@react-types/shared": "^3.18.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/react-aria-components/node_modules/react-stately": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.23.0.tgz",
+      "integrity": "sha512-nk2ihInebz5s+eDcXeEL+e2AbP9g0Mp9Gx5GEgqfICc8CKoYWERQsukXphGc6WEvFpAjVde7Q33hqusIqAO5gA==",
+      "dependencies": {
+        "@react-stately/calendar": "^3.2.1",
+        "@react-stately/checkbox": "^3.4.2",
+        "@react-stately/collections": "^3.8.0",
+        "@react-stately/combobox": "^3.5.1",
+        "@react-stately/data": "^3.9.2",
+        "@react-stately/datepicker": "^3.4.1",
+        "@react-stately/dnd": "^3.2.1",
+        "@react-stately/list": "^3.8.1",
+        "@react-stately/menu": "^3.5.2",
+        "@react-stately/numberfield": "^3.4.2",
+        "@react-stately/overlays": "^3.5.2",
+        "@react-stately/radio": "^3.8.1",
+        "@react-stately/searchfield": "^3.4.2",
+        "@react-stately/select": "^3.5.1",
+        "@react-stately/selection": "^3.13.1",
+        "@react-stately/slider": "^3.3.2",
+        "@react-stately/table": "^3.9.1",
+        "@react-stately/tabs": "^3.4.1",
+        "@react-stately/toggle": "^3.5.2",
+        "@react-stately/tooltip": "^3.4.1",
+        "@react-stately/tree": "^3.6.1",
+        "@react-types/shared": "^3.18.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
     "node_modules/react-colorful": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
@@ -23316,6 +23438,14 @@
       "peerDependencies": {
         "react": "16.8.0 - 18",
         "react-dom": "16.8.0 - 18"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utif": {
@@ -28227,6 +28357,23 @@
         "@react-stately/tabs": "^3.4.1",
         "@react-types/shared": "^3.18.1",
         "@react-types/tabs": "^3.3.0",
+        "@swc/helpers": "^0.4.14"
+      }
+    },
+    "@react-aria/tag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.0.0.tgz",
+      "integrity": "sha512-UuYqlysitwv1e1SV9YJqUMV7P7Gg5triEljyJ90b4rtETRhGa+Qh6cVa1P8F4h5nPTwzqey47jAp45i1FSsH4w==",
+      "requires": {
+        "@react-aria/gridlist": "^3.4.0",
+        "@react-aria/i18n": "^3.7.2",
+        "@react-aria/interactions": "^3.15.1",
+        "@react-aria/label": "^3.5.2",
+        "@react-aria/selection": "^3.15.0",
+        "@react-aria/utils": "^3.17.0",
+        "@react-stately/list": "^3.8.1",
+        "@react-types/button": "^3.7.3",
+        "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.4.14"
       }
     },
@@ -39228,6 +39375,98 @@
         "@react-types/shared": "^3.18.0"
       }
     },
+    "react-aria-components": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-cv8+mF5AykoOH0nV2gkQqzJSz7Cqfv5p2kVup2HCRM5CSeourC69d6mKI5htka4XYcrw9E4G0KtRqQnc9/J4DA==",
+      "requires": {
+        "@internationalized/date": "^3.2.0",
+        "@react-aria/focus": "^3.12.1",
+        "@react-aria/utils": "^3.17.0",
+        "@react-stately/table": "^3.9.1",
+        "@react-types/grid": "^3.1.8",
+        "@react-types/shared": "^3.18.1",
+        "@react-types/table": "^3.6.1",
+        "@swc/helpers": "^0.4.14",
+        "react-aria": "^3.25.0",
+        "react-stately": "^3.23.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "dependencies": {
+        "react-aria": {
+          "version": "3.25.0",
+          "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.25.0.tgz",
+          "integrity": "sha512-nvahN6tUCnES9CXCKEzEHkWy7mH39KsQoCk6eehIT3eG1pw/eYUqXFAmmWIL3g2VDCiGavpSf1/BUTnAXE2VsQ==",
+          "requires": {
+            "@react-aria/breadcrumbs": "^3.5.2",
+            "@react-aria/button": "^3.7.2",
+            "@react-aria/calendar": "^3.3.0",
+            "@react-aria/checkbox": "^3.9.1",
+            "@react-aria/combobox": "^3.6.1",
+            "@react-aria/datepicker": "^3.4.1",
+            "@react-aria/dialog": "^3.5.2",
+            "@react-aria/dnd": "^3.2.1",
+            "@react-aria/focus": "^3.12.1",
+            "@react-aria/gridlist": "^3.4.0",
+            "@react-aria/i18n": "^3.7.2",
+            "@react-aria/interactions": "^3.15.1",
+            "@react-aria/label": "^3.5.2",
+            "@react-aria/link": "^3.5.1",
+            "@react-aria/listbox": "^3.9.1",
+            "@react-aria/menu": "^3.9.1",
+            "@react-aria/meter": "^3.4.2",
+            "@react-aria/numberfield": "^3.5.1",
+            "@react-aria/overlays": "^3.14.1",
+            "@react-aria/progress": "^3.4.2",
+            "@react-aria/radio": "^3.6.1",
+            "@react-aria/searchfield": "^3.5.2",
+            "@react-aria/select": "^3.10.1",
+            "@react-aria/selection": "^3.15.0",
+            "@react-aria/separator": "^3.3.2",
+            "@react-aria/slider": "^3.4.1",
+            "@react-aria/ssr": "^3.6.0",
+            "@react-aria/switch": "^3.5.1",
+            "@react-aria/table": "^3.9.1",
+            "@react-aria/tabs": "^3.6.0",
+            "@react-aria/tag": "^3.0.0",
+            "@react-aria/textfield": "^3.9.2",
+            "@react-aria/tooltip": "^3.5.1",
+            "@react-aria/utils": "^3.17.0",
+            "@react-aria/visually-hidden": "^3.8.1",
+            "@react-types/shared": "^3.18.1"
+          }
+        },
+        "react-stately": {
+          "version": "3.23.0",
+          "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.23.0.tgz",
+          "integrity": "sha512-nk2ihInebz5s+eDcXeEL+e2AbP9g0Mp9Gx5GEgqfICc8CKoYWERQsukXphGc6WEvFpAjVde7Q33hqusIqAO5gA==",
+          "requires": {
+            "@react-stately/calendar": "^3.2.1",
+            "@react-stately/checkbox": "^3.4.2",
+            "@react-stately/collections": "^3.8.0",
+            "@react-stately/combobox": "^3.5.1",
+            "@react-stately/data": "^3.9.2",
+            "@react-stately/datepicker": "^3.4.1",
+            "@react-stately/dnd": "^3.2.1",
+            "@react-stately/list": "^3.8.1",
+            "@react-stately/menu": "^3.5.2",
+            "@react-stately/numberfield": "^3.4.2",
+            "@react-stately/overlays": "^3.5.2",
+            "@react-stately/radio": "^3.8.1",
+            "@react-stately/searchfield": "^3.4.2",
+            "@react-stately/select": "^3.5.1",
+            "@react-stately/selection": "^3.13.1",
+            "@react-stately/slider": "^3.3.2",
+            "@react-stately/table": "^3.9.1",
+            "@react-stately/tabs": "^3.4.1",
+            "@react-stately/toggle": "^3.5.2",
+            "@react-stately/tooltip": "^3.4.1",
+            "@react-stately/tree": "^3.6.1",
+            "@react-types/shared": "^3.18.1"
+          }
+        }
+      }
+    },
     "react-colorful": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
@@ -41766,6 +42005,11 @@
       "requires": {
         "@juggle/resize-observer": "^3.3.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "utif": {
       "version": "2.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "lodash": "4.17.21",
     "react": "18.2.0",
     "react-aria": "3.24.0",
+    "react-aria-components": "1.0.0-alpha.4",
     "react-dom": "18.2.0",
     "react-hot-toast": "2.4.0",
     "react-icons": "4.8.0",

--- a/client/src/components/uikit/Checkbox/Checkbox.stories.tsx
+++ b/client/src/components/uikit/Checkbox/Checkbox.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import Stack from '../Stack';
 import Text from '../Text';
 import Checkbox from './index';
+import Stack from '~components/uikit/Stack';
 
 export default {
   title: 'Checkbox',
@@ -14,16 +14,18 @@ export const Example = () => {
 
   return (
     <div style={{ padding: 32 }}>
-      <Stack as="label" axis="x" spacing="small" align="center">
+      <Stack axis="y" spacing="large">
         <Checkbox
-          isChecked={isChecked}
+          isSelected={isChecked}
           onChange={setChecked}
-          labelledby="sluibs-label"
+          label="Sluibs?"
         />
 
-        <Text variant="body" as="label" id="sluibs-label">
-          Sluibs?
-        </Text>
+        <Checkbox label={<Text variant="bodyStrong">Custom label</Text>} />
+
+        <Checkbox isDisabled label="I'm disabled" />
+
+        <Checkbox isIndeterminate label="I'm not sure about myself" />
       </Stack>
     </div>
   );

--- a/client/src/components/uikit/Checkbox/index.tsx
+++ b/client/src/components/uikit/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, ComponentProps } from 'react';
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { Checkbox as AriaCheckbox } from 'react-aria-components';
@@ -6,7 +6,7 @@ import { HiCheck, HiMinusSm } from 'react-icons/hi';
 
 import Icon from '../Icon';
 
-type CommonProps = React.ComponentProps<typeof AriaCheckbox>;
+type CommonProps = ComponentProps<typeof AriaCheckbox>;
 
 type PropsWithLabel = CommonProps & {
   /** Text string to be displayed next to the checkbox */

--- a/client/src/components/uikit/ComboBox/ComboBox.stories.tsx
+++ b/client/src/components/uikit/ComboBox/ComboBox.stories.tsx
@@ -1,0 +1,43 @@
+import { FaAward } from 'react-icons/fa';
+
+import Stack from '../Stack';
+import ComboBox from './index';
+
+export default {
+  title: 'ComboBox',
+  component: ComboBox,
+};
+
+export function Example() {
+  const options = [
+    { label: 'Cat', value: '1' },
+    { label: 'Dog', value: '2' },
+    { label: 'Horse', value: '3' },
+    { label: 'Cow', value: '4' },
+    { label: 'Horseradish', value: '5' },
+  ];
+
+  return (
+    <Stack axis="y" spacing="large" style={{ maxWidth: 400 }}>
+      <ComboBox label="Regular combobox" defaultItems={options} />
+
+      <ComboBox label="Disabled combobox" defaultItems={options} isDisabled />
+
+      <ComboBox label="Required combobox" defaultItems={options} isRequired />
+
+      <ComboBox label="With icon" icon={FaAward} defaultItems={options} />
+
+      <ComboBox
+        label="Descriptions also"
+        description="You should pick the third one"
+        defaultItems={options}
+      />
+
+      <ComboBox
+        label="Some invalid choice"
+        errorMessage="This is really bad"
+        defaultItems={options}
+      />
+    </Stack>
+  );
+}

--- a/client/src/components/uikit/ComboBox/index.tsx
+++ b/client/src/components/uikit/ComboBox/index.tsx
@@ -1,0 +1,107 @@
+import { forwardRef, useState } from 'react';
+import styled from 'styled-components';
+import {
+  Button,
+  Popover,
+  ComboBox as AriaComboBox,
+  Item,
+  Input as AriaInput,
+} from 'react-aria-components';
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import type { IconType } from 'react-icons';
+
+import {
+  baseInputStyles,
+  DescriptionText,
+  ErrorText,
+  InputIconLeft,
+  inputWrapperStyles,
+  Label,
+} from '~components/uikit/partials/common';
+import { ListBox } from '~components/uikit/partials/ListBox';
+import Icon from '~components/uikit/Icon';
+
+type Option = {
+  value: string;
+  label: string;
+};
+
+type Props = React.ComponentProps<typeof AriaComboBox<Option>> & {
+  label: string;
+  description?: string;
+  /** Passing an `errorMessage` as prop toggles the input as invalid. */
+  errorMessage?: string;
+  placeholder?: string;
+  icon?: IconType;
+};
+
+/**
+ * The `value`s of each option MUST be unique, otherwise render bugs will occur.
+ *
+ * Ref: https://react-spectrum.adobe.com/react-aria/ComboBox.html
+ */
+const ComboBox = forwardRef<HTMLInputElement, Props>(
+  ({ label, description, errorMessage, placeholder, icon, ...rest }, ref) => (
+    <Wrapper
+      {...rest}
+      ref={ref}
+      validationState={errorMessage ? 'invalid' : 'valid'}
+    >
+      <Label data-required={rest.isRequired}>{label}</Label>
+      <InputWrapper>
+        {icon && <InputIconLeft icon={icon} size={20} color="muted1" />}
+
+        <Input placeholder={placeholder} />
+
+        <InputButton>
+          <Icon icon={FaChevronDown} size={12} color="muted1" />
+        </InputButton>
+      </InputWrapper>
+
+      {description && <DescriptionText>{description}</DescriptionText>}
+      {errorMessage && <ErrorText>{errorMessage}</ErrorText>}
+
+      <Popover>
+        <ListBox>
+          {/* In cases like these, render props are preferred for perf reasons.
+           * Ref: https://react-spectrum.adobe.com/react-stately/collections.html#why-not-array-map
+           */}
+          {({ label, value }: Option) => <Item id={value}>{label}</Item>}
+        </ListBox>
+      </Popover>
+    </Wrapper>
+  )
+);
+
+const Wrapper = styled(AriaComboBox)`
+  ${inputWrapperStyles}
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+
+  & > svg + input {
+    padding-left: ${p => p.theme.spacing.xlarge}px;
+  }
+`;
+
+const Input = styled(AriaInput)`
+  ${baseInputStyles}
+
+  padding-right: ${p => p.theme.spacing.large}px;
+`;
+
+const InputButton = styled(Button)`
+  position: absolute;
+  height: 100%;
+  top: 0;
+  right: 0;
+  padding-right: ${p => p.theme.spacing.small}px;
+  padding-left: ${p => p.theme.spacing.small}px;
+
+  display: flex;
+  align-items: center;
+`;
+
+ComboBox.displayName = 'ComboBox';
+export default ComboBox;

--- a/client/src/components/uikit/ComboBox/index.tsx
+++ b/client/src/components/uikit/ComboBox/index.tsx
@@ -7,7 +7,7 @@ import {
   Item,
   Input as AriaInput,
 } from 'react-aria-components';
-import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import { FaChevronDown } from 'react-icons/fa';
 import type { IconType } from 'react-icons';
 
 import {

--- a/client/src/components/uikit/ComboBox/index.tsx
+++ b/client/src/components/uikit/ComboBox/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef, ComponentProps } from 'react';
 import styled from 'styled-components';
 import {
   Button,
@@ -26,7 +26,7 @@ type Option = {
   label: string;
 };
 
-type Props = React.ComponentProps<typeof AriaComboBox<Option>> & {
+type Props = ComponentProps<typeof AriaComboBox<Option>> & {
   label: string;
   description?: string;
   /** Passing an `errorMessage` as prop toggles the input as invalid. */

--- a/client/src/components/uikit/Select/Select.stories.tsx
+++ b/client/src/components/uikit/Select/Select.stories.tsx
@@ -1,4 +1,3 @@
-import { useState, ComponentProps } from 'react';
 import { FaAward } from 'react-icons/fa';
 
 import Stack from '../Stack';
@@ -11,7 +10,6 @@ export default {
 
 export function Example() {
   const options = [
-    { label: '', value: '' },
     { label: 'Option 1', value: '1' },
     { label: 'Option 2', value: '2' },
     { label: 'Option 3', value: '3' },
@@ -21,32 +19,25 @@ export function Example() {
 
   return (
     <Stack axis="y" spacing="large" style={{ maxWidth: 400 }}>
-      <TextInputExample label="Regular select" options={options} />
-      <TextInputExample label="With icon" icon={FaAward} options={options} />
-      <TextInputExample
-        label="With info message"
-        message="Hi, I'm a message about this select"
-        options={options}
+      <Select label="Regular select" items={options} />
+
+      <Select label="Disabled select" items={options} isDisabled />
+
+      <Select label="Required select" items={options} isRequired />
+
+      <Select label="With icon" icon={FaAward} items={options} />
+
+      <Select
+        label="Descriptions also"
+        description="You should pick the third one"
+        items={options}
       />
-      <TextInputExample
-        label="Invalid select"
-        isValid={false}
-        message="Something wrong!"
-        options={options}
+
+      <Select
+        label="Some invalid choice"
+        errorMessage="This is really bad"
+        items={options}
       />
     </Stack>
-  );
-}
-
-function TextInputExample(
-  props: Omit<ComponentProps<typeof Select>, 'value' | 'onChange'>
-) {
-  const [value, setValue] = useState('');
-  return (
-    <Select
-      {...props}
-      value={value}
-      onChange={(e: any) => setValue(e.currentTarget.value)}
-    />
   );
 }

--- a/client/src/components/uikit/Select/index.tsx
+++ b/client/src/components/uikit/Select/index.tsx
@@ -1,243 +1,99 @@
-import { InputHTMLAttributes, forwardRef, useState } from 'react';
-import styled, { css } from 'styled-components';
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+import {
+  Button,
+  Popover,
+  Select as AriaSelect,
+  SelectValue,
+  Item,
+} from 'react-aria-components';
 import { FaChevronDown } from 'react-icons/fa';
 import type { IconType } from 'react-icons';
 
-import Text from '../Text';
-import Icon from '../Icon';
+import {
+  baseInputStyles,
+  DescriptionText,
+  ErrorText,
+  InputIconLeft,
+  InputIconRight,
+  inputWrapperStyles,
+  Label,
+} from '~components/uikit/partials/common';
+import { ListBox } from '~components/uikit/partials/ListBox';
 
 type Option = {
   value: string;
   label: string;
 };
 
-type Props = InputHTMLAttributes<HTMLSelectElement> & {
-  options: Option[];
+type Props = React.ComponentProps<typeof AriaSelect<Option>> & {
   label: string;
+  description?: string;
+  /** Passing an `errorMessage` as prop toggles the input as invalid. */
+  errorMessage?: string;
   icon?: IconType;
-  isValid?: boolean;
-  isRequired?: boolean;
-  message?: string;
 };
 
-const Select = forwardRef(
-  (
-    {
-      value,
-      options,
-      label,
-      icon,
-      onChange,
-      message,
-      isValid = true,
-      isRequired = false,
-      className,
-      style,
-      ...rest
-    }: Props,
-    ref: any
-  ) => {
-    const [isFocused, setFocused] = useState(false);
-    const onFocus = () => setFocused(true);
-    const onBlur = () => setFocused(false);
-    const id = `select-${label.toLowerCase().replace(/\s/g, '')}`;
+/**
+ * The `value`s of each option MUST be unique, otherwise render bugs will occur.
+ *
+ * Ref: https://react-spectrum.adobe.com/react-aria/Select.html
+ */
+const Select = forwardRef<HTMLDivElement, Props>(
+  ({ label, description, errorMessage, icon, ...rest }, ref) => (
+    <Wrapper
+      {...rest}
+      ref={ref}
+      validationState={errorMessage ? 'invalid' : 'valid'}
+    >
+      <Label data-required={rest.isRequired}>{label}</Label>
+      <InputWrapper>
+        {icon && <InputIconLeft icon={icon} size={20} color="muted1" />}
 
-    return (
-      <Wrapper className={className} style={style}>
-        <Label
-          htmlFor={id}
-          isValid={isValid}
-          isAnimated={isFocused || !!value}
-          hasIcon={!!icon}
-        >
-          {label}
-          {isRequired && <span aria-hidden="true">*</span>}
-        </Label>
+        <Input data-invalid={!!errorMessage}>
+          <SelectValue />
+        </Input>
 
-        <InputWrapper isValid={isValid}>
-          {icon && (
-            <IconWrapper>
-              <Icon icon={icon} size={20} color="muted1" />
-            </IconWrapper>
-          )}
+        <InputIconRight icon={FaChevronDown} size={12} color="muted1" />
+      </InputWrapper>
 
-          <SelectInput
-            {...rest}
-            ref={ref}
-            id={id}
-            value={value}
-            onChange={onChange}
-            onBlur={onBlur}
-            onFocus={onFocus}
-            hasIcon={!!icon}
-          >
-            {options.map(({ value, label }) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </SelectInput>
+      {description && <DescriptionText>{description}</DescriptionText>}
+      {errorMessage && <ErrorText>{errorMessage}</ErrorText>}
 
-          <ArrowDown aria-hidden="true" className="select-arrow">
-            <Icon icon={FaChevronDown} size={12} color="muted1" />
-          </ArrowDown>
-
-          <Fieldset aria-hidden="true" isValid={isValid} isFocused={isFocused}>
-            <Legend isValid={isValid} isAnimated={isFocused || !!value}>
-              <span>
-                {label}
-                {isRequired ? '*' : ''}
-              </span>
-            </Legend>
-          </Fieldset>
-        </InputWrapper>
-
-        {/* TODO: figure out the a11y part of this message... */}
-        {!!message && (
-          <Message variant="bodySmall" color={isValid ? 'text' : 'warnText'}>
-            {message}
-          </Message>
-        )}
-      </Wrapper>
-    );
-  }
+      <Popover>
+        <ListBox>
+          {/* In cases like these, render props are preferred for perf reasons.
+           * Ref: https://react-spectrum.adobe.com/react-stately/collections.html#why-not-array-map
+           */}
+          {({ label, value }: Option) => <Item id={value}>{label}</Item>}
+        </ListBox>
+      </Popover>
+    </Wrapper>
+  )
 );
 
-const Wrapper = styled.div`
+const Wrapper = styled(AriaSelect)`
+  ${inputWrapperStyles}
+`;
+
+const InputWrapper = styled.div`
   position: relative;
-  display: flex;
-  flex-direction: column;
-  z-index: 0;
-  min-width: 200px;
-`;
 
-type LabelProps = { isAnimated: boolean; isValid: boolean; hasIcon: boolean };
-
-const Label = styled.label<LabelProps>`
-  ${p => p.theme.typography.body}
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  line-height: 1;
-  pointer-events: none;
-  color: ${p => p.theme.colors.muted1};
-  transform-origin: top left;
-  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-  transform: ${p =>
-    `translate(${
-      p.theme.spacing.normal + (p.hasIcon ? p.theme.spacing.large : 0)
-    }px, ${p.theme.spacing.normal + 2}px) scale(1)`};
-
-  ${p =>
-    p.isAnimated &&
-    css`
-      color: ${p.theme.colors[p.isValid ? 'info' : 'warn']};
-      transform: translate(16px, -6px) scale(0.75);
-    `}
-`;
-
-const InputWrapper = styled.div<{ isValid: boolean }>`
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  border-radius: ${p => p.theme.radii.normal}px;
-`;
-
-const Fieldset = styled.fieldset<{ isValid: boolean; isFocused: boolean }>`
-  position: absolute;
-  left: 0;
-  top: -6px;
-  bottom: 0;
-  right: 0;
-  overflow: hidden;
-  pointer-events: none;
-  margin: 0;
-  padding: ${p => p.theme.spacing.normal}px ${p => p.theme.spacing.small}px;
-  border-radius: inherit;
-  border: 1px solid ${p => p.theme.colors[p.isValid ? 'border' : 'warn']};
-
-  ${p =>
-    p.isFocused &&
-    css`
-      border-color: ${p.theme.colors[p.isValid ? 'info' : 'warn']};
-    `}
-`;
-
-const Legend = styled.legend<{ isAnimated: boolean; isValid: boolean }>`
-  width: auto;
-  height: 12px;
-  display: block;
-  padding: 0;
-  font-size: 0.75em;
-  max-width: 0.01px;
-  text-align: left;
-  transition: max-width 50ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-  visibility: hidden;
-
-  span {
-    display: inline-block;
-    padding-left: 4px;
-    padding-right: 4px;
-  }
-
-  ${p =>
-    p.isAnimated &&
-    css`
-      max-width: 1000px;
-      transition: max-width 100ms cubic-bezier(0, 0, 0.2, 1) 50ms;
-    `}
-`;
-
-const IconWrapper = styled.div`
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding-left: ${p => p.theme.spacing.normal}px;
-  pointer-events: none;
-`;
-
-const SelectInput = styled.select<{ hasIcon: boolean }>`
-  ${p => p.theme.typography.body}
-  color: ${p => p.theme.colors.text};
-  flex-grow: 1;
-  padding-top: ${p => p.theme.spacing.normal}px;
-  padding-bottom: ${p => p.theme.spacing.normal}px;
-  padding-right: ${p => p.theme.spacing.normal}px;
-  padding-left: ${p =>
-    p.hasIcon ? p.theme.spacing.xlarge + 8 : p.theme.spacing.normal}px;
-  border-radius: inherit;
-
-  &::placeholder {
-    color: transparent;
-  }
-
-  &:focus {
-    &::placeholder {
-      color: ${p => p.theme.colors.muted1};
-    }
+  & > svg + button {
+    padding-left: ${p => p.theme.spacing.xlarge}px;
   }
 `;
 
-const ArrowDown = styled.span`
-  display: inline-block;
-  position: absolute;
-  right: ${p => p.theme.spacing.normal}px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-`;
+const Input = styled(Button)`
+  ${baseInputStyles}
 
-const Message = styled(Text)`
-  margin-top: ${p => p.theme.spacing.xsmall}px;
-  margin-left: ${p => p.theme.spacing.xsmall}px;
+  padding-right: ${p => p.theme.spacing.xlarge}px;
+  text-align: inherit;
+
+  & > *[data-placeholder] {
+    color: ${p => p.theme.colors.muted1};
+  }
 `;
 
 Select.displayName = 'Select';
-
 export default Select;

--- a/client/src/components/uikit/Select/index.tsx
+++ b/client/src/components/uikit/Select/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, ComponentProps } from 'react';
 import styled from 'styled-components';
 import {
   Button,
@@ -26,7 +26,7 @@ type Option = {
   label: string;
 };
 
-type Props = React.ComponentProps<typeof AriaSelect<Option>> & {
+type Props = ComponentProps<typeof AriaSelect<Option>> & {
   label: string;
   description?: string;
   /** Passing an `errorMessage` as prop toggles the input as invalid. */

--- a/client/src/components/uikit/TextInput/TextInput.stories.tsx
+++ b/client/src/components/uikit/TextInput/TextInput.stories.tsx
@@ -1,5 +1,4 @@
-import { useState, ComponentProps } from 'react';
-import { FaAddressBook, FaUser, FaMailBulk } from 'react-icons/fa';
+import { FaMailBulk } from 'react-icons/fa';
 
 import Stack from '../Stack';
 import TextInput from './index';
@@ -12,37 +11,24 @@ export default {
 export function Example() {
   return (
     <Stack axis="y" spacing="large" style={{ maxWidth: 400 }}>
-      <TextInputExample label="Default input" />
-      <TextInputExample label="Input with an icon" icon={FaAddressBook} />
+      <TextInput label="Test input" />
 
-      <TextInputExample label="Required input" icon={FaUser} isRequired />
+      <TextInput label="Disabled input" isDisabled />
 
-      <TextInputExample
-        label="Input with info message"
-        message="This is an info message"
+      <TextInput label="Placeholder input" placeholder="Tell me why" />
+
+      <TextInput label="Required input" isRequired />
+
+      <TextInput
+        label="Input with description"
+        description="You should fill this one"
       />
 
-      <TextInputExample
-        label="Input with placeholder and validation"
-        placeholder="john@doe.com"
-        icon={FaMailBulk}
-        isValid={false}
-        message="Incorrect email address"
-      />
+      <TextInput label="Erroring input" errorMessage="Please don't do this" />
+
+      <TextInput label="Icon input" icon={FaMailBulk} />
+
+      <TextInput label="Password input" type="password" />
     </Stack>
-  );
-}
-
-function TextInputExample(
-  props: Omit<ComponentProps<typeof TextInput>, 'value' | 'onChange'>
-) {
-  const [value, setValue] = useState('');
-
-  return (
-    <TextInput
-      {...props}
-      value={value}
-      onChange={(e: any) => setValue(e.currentTarget.value)}
-    />
   );
 }

--- a/client/src/components/uikit/TextInput/index.tsx
+++ b/client/src/components/uikit/TextInput/index.tsx
@@ -1,266 +1,174 @@
-import { useRef, useState, forwardRef, InputHTMLAttributes } from 'react';
-import styled, { css } from 'styled-components';
-import mergeRefs from 'react-merge-refs';
-import { useTextField, mergeProps, FocusRing } from 'react-aria';
+import { useState, forwardRef } from 'react';
+import styled from 'styled-components';
+import {
+  TextField,
+  Label as AriaLabel,
+  Input as AriaInput,
+  Text as AriaText,
+  ToggleButton,
+} from 'react-aria-components';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
 import type { IconType } from 'react-icons';
 
-import Text from '../Text';
 import Icon from '../Icon';
 import { focusRing } from '~utils/styled';
+import { HiExclamation } from 'react-icons/hi';
 
-type Props = InputHTMLAttributes<HTMLInputElement> & {
+type Props = React.ComponentProps<typeof TextField> & {
   label: string;
   icon?: IconType;
-  isValid?: boolean;
-  isRequired?: boolean;
-  allowSecureTextToggle?: boolean;
-  message?: string;
-  as?: any;
+  description?: string;
+  /** Passing an `errorMessage` as prop toggles the input as invalid. */
+  errorMessage?: string;
+  placeholder?: string;
 };
 
-const TextInput = forwardRef(
-  (
-    {
-      value,
-      label,
-      icon,
-      type,
-      onChange,
-      message,
-      placeholder = '',
-      isValid = true,
-      isRequired = false,
-      allowSecureTextToggle = type === 'password',
-      className,
-      style,
-      as,
-      ...rest
-    }: Props,
-    ref: any
-  ) => {
-    const localRef = useRef<HTMLInputElement>(null);
-    const [secureTextVisible, setSecureTextVisible] = useState(false);
-    const [isFocused, setFocused] = useState(false);
-    const onFocus = () => setFocused(true);
-    const onBlur = () => setFocused(false);
-
-    const { labelProps, inputProps } = useTextField(
-      {
-        ...(rest as any),
-        label,
-        placeholder,
-        value,
-        isRequired,
-        onFocus,
-        onBlur,
-        type: allowSecureTextToggle ? secureTextVisible ? 'text' : 'password' : type, // prettier-ignore
-      },
-      localRef
-    );
-
-    const mergedProps = mergeProps(inputProps, rest);
+/**
+ * Ref: https://react-spectrum.adobe.com/react-aria/TextField.html
+ */
+const TextInput = forwardRef<HTMLInputElement, Props>(
+  ({ label, icon, description, errorMessage, placeholder, ...rest }, ref) => {
+    const [passwordVisible, setPasswordVisible] = useState(false);
+    const isPassword = rest.type === 'password';
 
     return (
-      <Wrapper className={className} style={style}>
-        <Label
-          {...labelProps}
-          isValid={isValid}
-          isAnimated={isFocused || !!value}
-          hasIcon={!!icon}
-        >
+      <Wrapper
+        {...rest}
+        validationState={errorMessage ? 'invalid' : 'valid'}
+        data-password={isPassword || undefined}
+        type={isPassword ? (passwordVisible ? 'text' : 'password') : rest.type}
+      >
+        <Label>
           {label}
-          {isRequired && <span aria-hidden="true">*</span>}
+          {rest.isRequired && <span aria-hidden="true"> *</span>}
         </Label>
 
-        <InputWrapper isValid={isValid}>
-          {icon && (
-            <IconWrapper>
-              <Icon icon={icon} size={20} color="muted1" />
-            </IconWrapper>
+        <InputWrapper>
+          {icon && <InputIcon icon={icon} size={20} color="muted1" />}
+
+          <Input ref={ref} placeholder={placeholder} />
+
+          {isPassword && (
+            <PasswordToggleButton
+              isSelected={passwordVisible}
+              onChange={setPasswordVisible}
+              aria-label="Show password"
+            >
+              <Icon
+                icon={passwordVisible ? FiEyeOff : FiEye}
+                size={20}
+                color="muted1"
+              />
+            </PasswordToggleButton>
           )}
-
-          <Input
-            {...mergedProps}
-            as={as}
-            ref={mergeRefs([localRef, ref])}
-            onChange={onChange}
-            hasIcon={!!icon}
-          />
-
-          {allowSecureTextToggle && (
-            <FocusRing focusRingClass="secure-text-button-focus">
-              <SecureTextButton
-                type="button"
-                onClick={() => setSecureTextVisible(p => !p)}
-              >
-                <Icon
-                  icon={secureTextVisible ? FiEyeOff : FiEye}
-                  size={20}
-                  color="muted1"
-                />
-              </SecureTextButton>
-            </FocusRing>
-          )}
-
-          <Fieldset aria-hidden="true" isValid={isValid} isFocused={isFocused}>
-            <Legend isValid={isValid} isAnimated={isFocused || !!value}>
-              <span>
-                {label}
-                {isRequired ? '*' : ''}
-              </span>
-            </Legend>
-          </Fieldset>
         </InputWrapper>
 
-        {/* TODO: figure out the a11y part of this message... */}
-        {!!message && (
-          <Message variant="bodySmall" color={isValid ? 'text' : 'warnText'}>
-            {message}
-          </Message>
+        {description && (
+          <DescriptionText slot="description">{description}</DescriptionText>
+        )}
+        {errorMessage && (
+          <ErrorText slot="errorMessage">
+            <Icon icon={HiExclamation} size={14} color="error" />
+            {errorMessage}
+          </ErrorText>
         )}
       </Wrapper>
     );
   }
 );
 
-const Wrapper = styled.div`
-  position: relative;
+const Wrapper = styled(TextField)`
   display: flex;
   flex-direction: column;
-  z-index: 0;
+  gap: ${p => p.theme.spacing.xxsmall}px;
 `;
 
-type LabelProps = { isAnimated: boolean; isValid: boolean; hasIcon: boolean };
-
-const Label = styled.label<LabelProps>`
+const Label = styled(AriaLabel)`
+  color: ${p => p.theme.colors.primaryText};
   ${p => p.theme.typography.body}
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  line-height: 1;
-  pointer-events: none;
-  color: ${p => p.theme.colors.muted1};
-  transform-origin: top left;
-  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-  transform: ${p =>
-    `translate(${
-      p.theme.spacing.normal + (p.hasIcon ? p.theme.spacing.large : 0)
-    }px, ${p.theme.spacing.normal + 2}px) scale(1)`};
-
-  ${p =>
-    p.isAnimated &&
-    css`
-      color: ${p.theme.colors[p.isValid ? 'primary' : 'warnText']};
-      transform: translate(16px, -6px) scale(0.75);
-    `}
 `;
 
-const InputWrapper = styled.div<{ isValid: boolean }>`
+const InputWrapper = styled.div`
   position: relative;
-  display: flex;
-  flex-direction: row;
-  border-radius: ${p => p.theme.radii.normal}px;
-`;
 
-const Fieldset = styled.fieldset<{ isValid: boolean; isFocused: boolean }>`
-  position: absolute;
-  left: 0;
-  top: -6px;
-  bottom: 0;
-  right: 0;
-  overflow: hidden;
-  pointer-events: none;
-  margin: 0;
-  padding: ${p => p.theme.spacing.normal}px ${p => p.theme.spacing.small}px;
-  border-radius: inherit;
-  border: 1px solid ${p => p.theme.colors[p.isValid ? 'border' : 'warn']};
-
-  ${p =>
-    p.isFocused &&
-    css`
-      border-color: ${p.theme.colors[p.isValid ? 'primary' : 'warn']};
-    `}
-`;
-
-const Legend = styled.legend<{ isAnimated: boolean; isValid: boolean }>`
-  width: auto;
-  height: 12px;
-  display: block;
-  padding: 0;
-  font-size: 0.75em;
-  max-width: 0.01px;
-  text-align: left;
-  transition: max-width 50ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-  visibility: hidden;
-
-  span {
-    display: inline-block;
-    padding-left: 4px;
-    padding-right: 4px;
+  & > svg + input {
+    padding-left: ${p => p.theme.spacing.xlarge}px;
   }
 
-  ${p =>
-    p.isAnimated &&
-    css`
-      max-width: 1000px;
-      transition: max-width 100ms cubic-bezier(0, 0, 0.2, 1) 50ms;
-    `}
+  & > input[data-password] {
+    padding-right: ${p => p.theme.spacing.xlarge}px;
+  }
 `;
 
-const IconWrapper = styled.div`
+const InputIcon = styled(Icon)`
   position: absolute;
-  left: 0;
+  margin-left: ${p => p.theme.spacing.normal}px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
+const PasswordToggleButton = styled(ToggleButton)`
+  position: absolute;
+  height: 100%;
   top: 0;
-  bottom: 0;
+  right: 0;
+  padding-right: ${p => p.theme.spacing.small}px;
+  padding-left: ${p => p.theme.spacing.small}px;
+
   display: flex;
-  justify-content: center;
   align-items: center;
-  padding-left: ${p => p.theme.spacing.normal}px;
-  pointer-events: none;
-`;
 
-const Input = styled.input<{ hasIcon: boolean }>`
-  ${p => p.theme.typography.body}
-  color: ${p => p.theme.colors.text};
-  flex-grow: 1;
-  padding-top: ${p => p.theme.spacing.normal}px;
-  padding-bottom: ${p => p.theme.spacing.normal}px;
-  padding-right: ${p => p.theme.spacing.normal}px;
-  padding-left: ${p =>
-    p.hasIcon ? p.theme.spacing.xlarge + 8 : p.theme.spacing.normal}px;
-  border-radius: inherit;
-
-  &::placeholder {
-    color: transparent;
-  }
-
-  &:focus {
-    &::placeholder {
-      color: ${p => p.theme.colors.muted1};
-    }
-  }
-`;
-
-const Message = styled(Text)`
-  margin-top: ${p => p.theme.spacing.xsmall}px;
-  margin-left: ${p => p.theme.spacing.xsmall}px;
-`;
-
-const SecureTextButton = styled.button`
-  justify-content: center;
-  align-items: center;
-  padding: 0px ${p => p.theme.spacing.small}px;
-  border-radius: 2px;
-  outline: none;
-
-  &.secure-text-button-focus {
+  &:focus-visible {
     ${focusRing}
   }
 `;
 
-TextInput.displayName = 'TextInput';
+const Input = styled(AriaInput)`
+  padding: ${p => p.theme.spacing.small}px;
 
+  width: 100%;
+
+  ${p => p.theme.typography.body};
+  color: ${p => p.theme.colors.text};
+
+  border-radius: ${p => p.theme.radii.normal}px;
+  border: 1px solid ${p => p.theme.colors.border};
+
+  --outline-width: 1px;
+  outline-offset: calc(0px - var(--outline-width));
+
+  &:focus {
+    border-color: transparent;
+    outline: var(--outline-width) solid ${p => p.theme.colors.primary};
+
+    --outline-width: 3px;
+  }
+
+  &[aria-invalid] {
+    border-color: transparent;
+    outline: var(--outline-width) solid ${p => p.theme.colors.error};
+  }
+
+  &[disabled] {
+    background-color: ${p => p.theme.colors.muted5};
+  }
+`;
+
+const DescriptionText = styled(AriaText)`
+  ${p => p.theme.typography.bodySmall};
+`;
+
+const ErrorText = styled(AriaText)`
+  ${p => p.theme.typography.bodySmall};
+  color: ${p => p.theme.colors.errorText};
+  display: flex;
+  align-items: center;
+
+  & > svg {
+    margin-right: ${p => p.theme.spacing.xxsmall}px;
+  }
+`;
+
+TextInput.displayName = 'TextInput';
 export default TextInput;

--- a/client/src/components/uikit/TextInput/index.tsx
+++ b/client/src/components/uikit/TextInput/index.tsx
@@ -2,9 +2,7 @@ import { useState, forwardRef } from 'react';
 import styled from 'styled-components';
 import {
   TextField,
-  Label as AriaLabel,
   Input as AriaInput,
-  Text as AriaText,
   ToggleButton,
 } from 'react-aria-components';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
@@ -12,7 +10,14 @@ import type { IconType } from 'react-icons';
 
 import Icon from '../Icon';
 import { focusRing } from '~utils/styled';
-import { HiExclamation } from 'react-icons/hi';
+import {
+  inputWrapperStyles,
+  InputIconLeft,
+  Label,
+  baseInputStyles,
+  DescriptionText,
+  ErrorText,
+} from '~components/uikit/partials/common';
 
 type Props = React.ComponentProps<typeof TextField> & {
   label: string;
@@ -32,21 +37,20 @@ const TextInput = forwardRef<HTMLInputElement, Props>(
     const isPassword = rest.type === 'password';
 
     return (
-      <Wrapper
-        {...rest}
-        validationState={errorMessage ? 'invalid' : 'valid'}
-        data-password={isPassword || undefined}
-        type={isPassword ? (passwordVisible ? 'text' : 'password') : rest.type}
-      >
-        <Label>
-          {label}
-          {rest.isRequired && <span aria-hidden="true"> *</span>}
-        </Label>
+      <Wrapper {...rest} validationState={errorMessage ? 'invalid' : 'valid'}>
+        <Label data-required={rest.isRequired}>{label}</Label>
 
         <InputWrapper>
-          {icon && <InputIcon icon={icon} size={20} color="muted1" />}
+          {icon && <InputIconLeft icon={icon} size={20} color="muted1" />}
 
-          <Input ref={ref} placeholder={placeholder} />
+          <Input
+            ref={ref}
+            placeholder={placeholder}
+            data-password={isPassword || undefined}
+            type={
+              isPassword ? (passwordVisible ? 'text' : 'password') : rest.type
+            }
+          />
 
           {isPassword && (
             <PasswordToggleButton
@@ -63,29 +67,15 @@ const TextInput = forwardRef<HTMLInputElement, Props>(
           )}
         </InputWrapper>
 
-        {description && (
-          <DescriptionText slot="description">{description}</DescriptionText>
-        )}
-        {errorMessage && (
-          <ErrorText slot="errorMessage">
-            <Icon icon={HiExclamation} size={14} color="error" />
-            {errorMessage}
-          </ErrorText>
-        )}
+        {description && <DescriptionText>{description}</DescriptionText>}
+        {errorMessage && <ErrorText>{errorMessage}</ErrorText>}
       </Wrapper>
     );
   }
 );
 
 const Wrapper = styled(TextField)`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.spacing.xxsmall}px;
-`;
-
-const Label = styled(AriaLabel)`
-  color: ${p => p.theme.colors.primaryText};
-  ${p => p.theme.typography.body}
+  ${inputWrapperStyles}
 `;
 
 const InputWrapper = styled.div`
@@ -98,14 +88,6 @@ const InputWrapper = styled.div`
   & > input[data-password] {
     padding-right: ${p => p.theme.spacing.xlarge}px;
   }
-`;
-
-const InputIcon = styled(Icon)`
-  position: absolute;
-  margin-left: ${p => p.theme.spacing.normal}px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
 `;
 
 const PasswordToggleButton = styled(ToggleButton)`
@@ -125,49 +107,7 @@ const PasswordToggleButton = styled(ToggleButton)`
 `;
 
 const Input = styled(AriaInput)`
-  padding: ${p => p.theme.spacing.small}px;
-
-  width: 100%;
-
-  ${p => p.theme.typography.body};
-  color: ${p => p.theme.colors.text};
-
-  border-radius: ${p => p.theme.radii.normal}px;
-  border: 1px solid ${p => p.theme.colors.border};
-
-  --outline-width: 1px;
-  outline-offset: calc(0px - var(--outline-width));
-
-  &:focus {
-    border-color: transparent;
-    outline: var(--outline-width) solid ${p => p.theme.colors.primary};
-
-    --outline-width: 3px;
-  }
-
-  &[aria-invalid] {
-    border-color: transparent;
-    outline: var(--outline-width) solid ${p => p.theme.colors.error};
-  }
-
-  &[disabled] {
-    background-color: ${p => p.theme.colors.muted5};
-  }
-`;
-
-const DescriptionText = styled(AriaText)`
-  ${p => p.theme.typography.bodySmall};
-`;
-
-const ErrorText = styled(AriaText)`
-  ${p => p.theme.typography.bodySmall};
-  color: ${p => p.theme.colors.errorText};
-  display: flex;
-  align-items: center;
-
-  & > svg {
-    margin-right: ${p => p.theme.spacing.xxsmall}px;
-  }
+  ${baseInputStyles}
 `;
 
 TextInput.displayName = 'TextInput';

--- a/client/src/components/uikit/TextInput/index.tsx
+++ b/client/src/components/uikit/TextInput/index.tsx
@@ -1,4 +1,6 @@
 import { useState, forwardRef, ComponentProps } from 'react';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import styled from 'styled-components';
 import {
   TextField,
@@ -33,6 +35,7 @@ type Props = ComponentProps<typeof TextField> & {
  */
 const TextInput = forwardRef<HTMLInputElement, Props>(
   ({ label, icon, description, errorMessage, placeholder, ...rest }, ref) => {
+    useLingui();
     const [passwordVisible, setPasswordVisible] = useState(false);
     const isPassword = rest.type === 'password';
 
@@ -56,7 +59,7 @@ const TextInput = forwardRef<HTMLInputElement, Props>(
             <PasswordToggleButton
               isSelected={passwordVisible}
               onChange={setPasswordVisible}
-              aria-label="Show password"
+              aria-label={t`Show password`}
             >
               <Icon
                 icon={passwordVisible ? FiEyeOff : FiEye}

--- a/client/src/components/uikit/TextInput/index.tsx
+++ b/client/src/components/uikit/TextInput/index.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef } from 'react';
+import { useState, forwardRef, ComponentProps } from 'react';
 import styled from 'styled-components';
 import {
   TextField,
@@ -19,7 +19,7 @@ import {
   ErrorText,
 } from '~components/uikit/partials/common';
 
-type Props = React.ComponentProps<typeof TextField> & {
+type Props = ComponentProps<typeof TextField> & {
   label: string;
   icon?: IconType;
   description?: string;

--- a/client/src/components/uikit/partials/ListBox.tsx
+++ b/client/src/components/uikit/partials/ListBox.tsx
@@ -6,10 +6,8 @@ export const ListBox = styled(AriaListBox)`
   padding: ${p => p.theme.spacing.xsmall}px;
   border: 1px solid ${p => p.theme.colors.border};
   border-radius: ${p => p.theme.radii.normal}px;
-
   background-color: ${p => p.theme.colors.elevated};
   box-shadow: ${p => p.theme.shadows.normal};
-
   outline: none;
 
   /* The 'Item' component isn't the actual thing that gets rendered, so we need

--- a/client/src/components/uikit/partials/ListBox.tsx
+++ b/client/src/components/uikit/partials/ListBox.tsx
@@ -29,8 +29,8 @@ export const ListBox = styled(AriaListBox)`
     }
 
     &[data-focused='true'] {
-      color: ${p => p.theme.colors.onPrimary};
-      background-color: ${p => p.theme.colors.primary};
+      color: ${p => p.theme.colors.primaryText};
+      background-color: ${p => p.theme.colors.primaryMuted};
       outline: none;
     }
   }

--- a/client/src/components/uikit/partials/ListBox.tsx
+++ b/client/src/components/uikit/partials/ListBox.tsx
@@ -1,5 +1,5 @@
 import { ListBox as AriaListBox } from 'react-aria-components';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const ListBox = styled(AriaListBox)`
   width: var(--trigger-width); /* magical var from react-aria */

--- a/client/src/components/uikit/partials/ListBox.tsx
+++ b/client/src/components/uikit/partials/ListBox.tsx
@@ -1,0 +1,39 @@
+import { ListBox as AriaListBox } from 'react-aria-components';
+import styled, { css } from 'styled-components';
+
+export const ListBox = styled(AriaListBox)`
+  width: var(--trigger-width); /* magical var from react-aria */
+  padding: ${p => p.theme.spacing.xsmall}px;
+  border: 1px solid ${p => p.theme.colors.border};
+  border-radius: ${p => p.theme.radii.normal}px;
+
+  background-color: ${p => p.theme.colors.elevated};
+  box-shadow: ${p => p.theme.shadows.normal};
+
+  outline: none;
+
+  /* The 'Item' component isn't the actual thing that gets rendered, so we need
+   * to style it indirectly */
+  .react-aria-Item {
+    position: relative;
+    padding: ${p => p.theme.spacing.xsmall}px ${p => p.theme.spacing.small}px;
+    padding-left: ${p => p.theme.spacing.medium}px;
+    border-radius: ${p => p.theme.radii.small}px;
+
+    &[aria-selected='true'] {
+      ${p => p.theme.typography.bodyStrong}
+
+      &:before {
+        content: '✓';
+        position: absolute;
+        left: 6px;
+      }
+    }
+
+    &[data-focused='true'] {
+      color: ${p => p.theme.colors.onPrimary};
+      background-color: ${p => p.theme.colors.primary};
+      outline: none;
+    }
+  }
+`;

--- a/client/src/components/uikit/partials/common.tsx
+++ b/client/src/components/uikit/partials/common.tsx
@@ -47,7 +47,7 @@ export const baseInputStyles = css`
  * Add a `data-required` attribute to render an `*` after the label
  */
 export const Label = styled(AriaLabel)`
-  color: ${p => p.theme.colors.primaryText};
+  color: ${p => p.theme.colors.text};
   ${p => p.theme.typography.body}
 
   &[data-required="true"]:after {

--- a/client/src/components/uikit/partials/common.tsx
+++ b/client/src/components/uikit/partials/common.tsx
@@ -1,3 +1,4 @@
+import { ComponentProps } from 'react';
 import { Label as AriaLabel, Text } from 'react-aria-components';
 import styled, { css } from 'styled-components';
 import { HiExclamation } from 'react-icons/hi';
@@ -90,7 +91,7 @@ const ErrorTextWrapper = styled(Text)`
 export const ErrorText = ({
   children,
   ...rest
-}: Omit<React.ComponentProps<typeof Text>, 'slot'>) => (
+}: Omit<ComponentProps<typeof Text>, 'slot'>) => (
   <ErrorTextWrapper {...rest} slot="errorMessage">
     <Icon icon={HiExclamation} size={14} color="error" />
     {children}

--- a/client/src/components/uikit/partials/common.tsx
+++ b/client/src/components/uikit/partials/common.tsx
@@ -1,0 +1,98 @@
+import { Label as AriaLabel, Text } from 'react-aria-components';
+import styled, { css } from 'styled-components';
+import { HiExclamation } from 'react-icons/hi';
+
+import Icon from '../Icon';
+
+export const inputWrapperStyles = css`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.spacing.xxsmall}px;
+`;
+
+export const baseInputStyles = css`
+  padding: ${p => p.theme.spacing.small}px;
+
+  width: 100%;
+
+  ${p => p.theme.typography.body};
+  color: ${p => p.theme.colors.text};
+
+  border-radius: ${p => p.theme.radii.normal}px;
+  border: 1px solid ${p => p.theme.colors.border};
+
+  --outline-width: 1px;
+  outline-offset: calc(0px - var(--outline-width));
+
+  &:focus {
+    border-color: transparent;
+    outline: var(--outline-width) solid ${p => p.theme.colors.primary};
+
+    --outline-width: 3px;
+  }
+
+  &[aria-invalid='true'],
+  &[data-invalid='true'] {
+    border-color: transparent;
+    outline: var(--outline-width) solid ${p => p.theme.colors.error};
+  }
+
+  &[disabled] {
+    background-color: ${p => p.theme.colors.muted5};
+    cursor: not-allowed;
+  }
+`;
+
+/**
+ * Add a `data-required` attribute to render an `*` after the label
+ */
+export const Label = styled(AriaLabel)`
+  color: ${p => p.theme.colors.primaryText};
+  ${p => p.theme.typography.body}
+
+  &[data-required="true"]:after {
+    content: ' *';
+  }
+`;
+
+export const InputIconLeft = styled(Icon)`
+  position: absolute;
+  margin-left: ${p => p.theme.spacing.normal}px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
+export const InputIconRight = styled(Icon)`
+  position: absolute;
+  margin-right: ${p => p.theme.spacing.normal}px;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
+export const DescriptionText = styled(Text).attrs({ slot: 'description' })`
+  ${p => p.theme.typography.bodySmall};
+`;
+
+const ErrorTextWrapper = styled(Text)`
+  ${p => p.theme.typography.bodySmall};
+  color: ${p => p.theme.colors.errorText};
+  display: flex;
+  align-items: center;
+
+  & > svg {
+    margin-right: ${p => p.theme.spacing.xxsmall}px;
+  }
+`;
+
+export const ErrorText = ({
+  children,
+  ...rest
+}: Omit<React.ComponentProps<typeof Text>, 'slot'>) => (
+  <ErrorTextWrapper {...rest} slot="errorMessage">
+    <Icon icon={HiExclamation} size={14} color="error" />
+    {children}
+  </ErrorTextWrapper>
+);

--- a/client/src/components/uikit/partials/common.tsx
+++ b/client/src/components/uikit/partials/common.tsx
@@ -73,9 +73,13 @@ export const InputIconRight = styled(Icon)`
   pointer-events: none;
 `;
 
-export const DescriptionText = styled(Text).attrs({ slot: 'description' })`
+const DescriptionTextWrapper = styled(Text).attrs({ slot: 'description' })`
   ${p => p.theme.typography.bodySmall};
 `;
+
+export const DescriptionText = (
+  props: Omit<ComponentProps<typeof Text>, 'slot'>
+) => <DescriptionTextWrapper {...props} slot="description" />;
 
 const ErrorTextWrapper = styled(Text)`
   ${p => p.theme.typography.bodySmall};


### PR DESCRIPTION
Reimplements a few UIKit components with `react-aria-components`

Commits should be quite clear for review, and changes easily testable in storybook

<hr />

![image](https://github.com/TaitoUnited/full-stack-template/assets/16649390/3b48f953-c77a-43db-9419-6aab285b5354)

- Now includes `label` as a prop that will render it on the right side of the checkbox
- Optionally, `labelledby` can be passed if only a checkbox without visible label is required
- Adds `indeterminate` as a state, useful for example for a "select all" checkbox on a table with only some rows checked

<hr />

![image](https://github.com/TaitoUnited/full-stack-template/assets/16649390/e3c901cd-fe0b-40bc-875c-460e0c0a9ba6)

- Styling changed a bit from floating label to a static one above the input box
    - Moving label is difficult from a11y perspective, as we would need to disable and move it to final position if user has `prefers-reduced-motion`
    - Placeholders don't work that cleanly with floating label
    - Me and Otto like the looks of this one better :stuck_out_tongue_winking_eye: 
- Error state styled a bit differently
    - `error` instead of `warn` color
    - Includes a warning triangle so that error message can be differentiated from an input description
- Description and error can be shown simultaneously

<hr />

![image](https://github.com/TaitoUnited/full-stack-template/assets/16649390/da3934f6-d194-4836-aa6d-9aeea001c4a1)

![image](https://github.com/TaitoUnited/full-stack-template/assets/16649390/61de4561-463e-4bb2-bd39-d291190488df)

![image](https://github.com/TaitoUnited/full-stack-template/assets/16649390/984c638b-10a7-4f24-807e-0a82dff0c11d)

- Reuses stylings from `TextInput`
- Popover list and options can be styled
    - Distinct styling for currently selected option and focused/hovered option
    - Can be bikeshed indefinitely :stuck_out_tongue: 
- Rename prop `options` -> `items` to mimic defaults of `react-aria(-components)`

<hr />

![image](https://github.com/TaitoUnited/full-stack-template/assets/16649390/cab62d8e-b937-4248-a054-7d105e723386)

- Newly implemented
- Shared styles with `Select`



