### PR TITLE
refactor(feature-flags): reduce feature flag repetition

### DIFF
--- a/client/src/constants/config.ts
+++ b/client/src/constants/config.ts
@@ -1,16 +1,4 @@
-export type AppEnv =
-  | 'localhost'
-  | 'feat'
-  | 'dev'
-  | 'test'
-  | 'uat'
-  | 'qa'
-  | 'stag'
-  | 'canary'
-  | 'cana'
-  | 'prod';
-
-export const appEnvironments: AppEnv[] = [
+export const appEnvironments = [
   'localhost',
   'feat',
   'dev',
@@ -21,7 +9,9 @@ export const appEnvironments: AppEnv[] = [
   'canary',
   'cana',
   'prod',
-];
+] as const;
+
+export type AppEnv = (typeof appEnvironments)[number];
 
 const subdomainSplit = window.location.hostname.split('.')[0].split('-');
 const envSuffix = subdomainSplit[subdomainSplit.length - 1] as AppEnv;

--- a/client/src/utils/feature-flags.ts
+++ b/client/src/utils/feature-flags.ts
@@ -1,14 +1,16 @@
 import config, { AppEnv, appEnvironments } from '~constants/config';
 
-export const features = ['feature-1', 'feature-2', 'feature-3'] as const;
-
-export type Feature = (typeof features)[number];
-
-const featureConfig: Record<Feature, AppEnv[]> = {
+const featureConfig = {
   'feature-1': appEnvironments, // enabled in all envs
   'feature-2': ['localhost', 'dev', 'test'],
   'feature-3': [], // this feature can be enabled via query param or feature flag manager
-};
+} as const satisfies Record<string, readonly AppEnv[]>;
+
+export type Feature = keyof typeof featureConfig;
+
+export const features = Object.keys(
+  featureConfig
+) as (keyof typeof featureConfig)[];
 
 export function isFeatureEnabled(feature: Feature) {
   return (
@@ -18,7 +20,7 @@ export function isFeatureEnabled(feature: Feature) {
 }
 
 export function isFeatureEnabledInConfig(feature: Feature) {
-  const envs = featureConfig[feature];
+  const envs: readonly AppEnv[] = featureConfig[feature];
   return envs.includes(config.ENV);
 }
 


### PR DESCRIPTION
Improved the typescript trickery, this way we only need to edit the `featureConfig` object and won't need to keep another array up-to-date in addition

The `AppEnv` definition came up with some typing errors initially so we'll improve it as a drive-by