### PR TITLE
Fix/styled system in prod build

### DIFF
--- a/client/styled-system/setup/config.ts
+++ b/client/styled-system/setup/config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   outdir: 'styled-system/generated',
 
   // Makse generated class names shorter and optimize css in non-dev mode
-  hash: isProd,
+  hash: false,
   optimize: isProd,
   minify: isProd,
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -30,6 +30,7 @@
         "koa-joi-router": "~8.0.0",
         "koa-jwt": "^4.0.3",
         "koa-qs": "~3.0.0",
+        "module-alias": "2.2.3",
         "mustache": "~4.2.0",
         "node-gyp": "9.3.1",
         "openapi-types": "^12.0.2",
@@ -11950,6 +11951,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
     },
     "node_modules/moment": {
       "version": "2.29.4",

--- a/server/package.json
+++ b/server/package.json
@@ -43,6 +43,7 @@
     "koa-joi-router": "~8.0.0",
     "koa-jwt": "^4.0.3",
     "koa-qs": "~3.0.0",
+    "module-alias": "2.2.3",
     "mustache": "~4.2.0",
     "node-gyp": "9.3.1",
     "openapi-types": "^12.0.2",


### PR DESCRIPTION
## ✨ What has changed?

<!--
Describe what changes have been made.
Please do not leave this blank.
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR fixes css styles in production build by disabling [hashing](https://panda-css.com/docs/references/config#hash) in pandacss. A missing dependency is also added to server.

## 🖇️ Related tickets & documents

<!--
Please use this format link issue numbers: Closes #
where # is the issue number you are closing as a link to the issue.
For multiple issues, separate them with a comma.
If there are documents, e.g. in Google Docs or Confluence, you can link them here as well [optional].
-->

Closes #162 

## 🔍 How to verify?

<!--
Describe how to test and verify the changes as part of the review.
Short and concise is the key, for example:
1. Navigate to...
2. Click on...
3. Scroll down to...
4. See the changes
-->

> [!IMPORTANT]  
> If the changes are visual remember to provide a screen recording or a set of screenshots of the implemented feature.

1. Run `taito start --clean --prod`
2. Run `taito open client`
3. The styles should work correctly now

## 🧪 Added tests?

- [ ] 👍 Yes
- [x] 🙅 No, why not?

<!-- If no tests are added, tell us why. -->

Does full stack template even have tests? And if it does, they clearly don't test the production build well enough, if at all.

## ✔️ Checklist

### General

- Implementation is **documented**
- Implementation is **tested** (prefer integration and e2e tests)

### Frontend

- Implementation is **translated**
- Implementation is **performant** (lazy-load components and pre-fetch data, etc.)
- Implementation is **accessible** (focus management, keyboard navigation, etc.)
- Incomplete features are hidden behind **feature flags**
- Implemented design is **consistent** (eg. design system is used)

### Backend

- Implementation is **secure** (authorization and validation has been applied, etc.)
- Implementation is **performant** (expensive data is cached, slow DB queries have proper indices, etc.)
