### PR TITLE
fix: separatre id from rest

### DIFF
--- a/client/src/components/uikit/TextInput/index.tsx
+++ b/client/src/components/uikit/TextInput/index.tsx
@@ -28,7 +28,10 @@ type Props = ComponentProps<typeof TextField> & {
  * Ref: https://react-spectrum.adobe.com/react-aria/TextField.html
  */
 const TextInput = forwardRef<HTMLInputElement, Props>(
-  ({ label, icon, description, errorMessage, placeholder, ...rest }, ref) => {
+  (
+    { label, icon, description, errorMessage, placeholder, id, ...rest },
+    ref
+  ) => {
     useLingui();
     const [passwordVisible, setPasswordVisible] = useState(false);
     const isPassword = rest.type === 'password';
@@ -61,6 +64,7 @@ const TextInput = forwardRef<HTMLInputElement, Props>(
 
           <Input
             ref={ref}
+            id={id}
             placeholder={placeholder}
             className={baseInputStyles}
             data-password={isPassword || undefined}


### PR DESCRIPTION
## ✨ What has changed?

This pr fixes the bug of the id showing up in the parent div of a textinput.

## 🖇️ Related tickets & documents

None

## 🔍 How to verify?

1. Insert a TextField somewhere or navigate to a place where it is used
2. Inspect and see that the id is not shown on the parent div

<img width="437" alt="Screenshot 2024-02-20 at 10 32 43" src="https://github.com/TaitoUnited/full-stack-template/assets/75121915/c4363aa1-3501-431c-aa50-5c01e8e46cf0">
<img width="450" alt="Screenshot 2024-02-20 at 10 32 20" src="https://github.com/TaitoUnited/full-stack-template/assets/75121915/9d8ed4c3-3b12-4ffc-a41f-9f9fef7378aa">
