### PR TITLE
Pass workspace id as param to redirect

### DIFF
--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/_app/')({
     const workspaceId = workspaceIdStore.getState().workspaceId;
 
     if (workspaceId) {
-      throw redirect({ to: `/${workspaceId}` });
+      throw redirect({ to: `/$workspaceId`, params: { workspaceId } });
     } else {
       await logout();
       throw redirect({ to: '/login' });

--- a/client/src/routes/layout.tsx
+++ b/client/src/routes/layout.tsx
@@ -41,13 +41,16 @@ export const Route = createFileRoute('/_app')({
       await logout();
       workspaceIdStore.setState({ workspaceId: '' });
       throw redirect({ to: '/login' });
-    } else if (!workspaceId) {
+    } else if (!workspaceId && workspaceIdFallback) {
       /**
        * If workspace from URL params was not found but the user has workspaces,
        * redirect to the first workspace as a fallback.
        */
       workspaceIdStore.setState({ workspaceId: workspaceIdFallback });
-      throw redirect({ to: `/${workspaceIdFallback}` });
+      throw redirect({
+        to: `/$workspaceId`,
+        params: { workspaceId: workspaceIdFallback },
+      });
     } else if (workspaceId !== workspaceIdStored) {
       /**
        * Otherwise if the workspace from URL params is different from


### PR DESCRIPTION
## ✨ What has changed?

Improve routing type safety by passing the workspace id via params instead of template string.

## 🔍 How to verify?

1. Login
2. Remove workspace id from url manually
3. Refresh
4. You should be redirected to the first workspace

> [!NOTE]  
> We need to decide if we call it `organisation`, `workspace` or remove it entirely from the template.