### PR TITLE
feat(client): improve date pickers usability

### DIFF
--- a/client/src/components/uikit/date-picker/index.tsx
+++ b/client/src/components/uikit/date-picker/index.tsx
@@ -197,7 +197,7 @@ export function DatePicker({
         }}
       >
         <DatePickerDialog>
-          <Calendar data-testid="date-picker-calendar">
+          <Calendar firstDayOfWeek="mon" data-testid="date-picker-calendar">
             {date => (
               <>
                 <CalendarHeader>
@@ -503,6 +503,11 @@ const CalendarCell = styled(AriaCalendarCell, {
 
     '&[data-disabled]': {
       color: '$neutral2',
+      cursor: 'not-allowed',
+    },
+
+    '&[data-outside-month]': {
+      display: 'none',
     },
 
     '&[data-selected]': {

--- a/client/src/components/uikit/date-range-picker/index.tsx
+++ b/client/src/components/uikit/date-range-picker/index.tsx
@@ -48,7 +48,7 @@ type DateRangePicker<T extends DateValue> = Omit<
   clearable?: boolean;
   preDefinable?: boolean;
   value: DateRange | null;
-  onChange?: (value: DateRange | null) => void;
+  onChange: (value: DateRange | null) => void;
 };
 
 /**
@@ -72,6 +72,8 @@ export function DateRangePicker<T extends DateValue>({
   clearable = false,
   preDefinable = false,
   value,
+  minValue,
+  maxValue,
   onChange,
   ...rest
 }: DateRangePicker<T>) {
@@ -175,6 +177,10 @@ export function DateRangePicker<T extends DateValue>({
             )}
             <RangeCalendar
               data-testid="date-range-picker-calendar"
+              firstDayOfWeek="mon"
+              maxValue={maxValue}
+              minValue={minValue}
+              defaultFocusedValue={value?.end}
               style={{
                 display: 'flex',
                 flexDirection: 'column',
@@ -443,6 +449,11 @@ const CalendarCell = styled(AriaCalendarCell, {
 
     '&[data-disabled]': {
       color: '$neutral2',
+      cursor: 'not-allowed',
+    },
+
+    '&[data-outside-month]': {
+      display: 'none',
     },
 
     '&[data-selected]': {

--- a/client/src/components/uikit/date-range-picker/predefined-ranges.tsx
+++ b/client/src/components/uikit/date-range-picker/predefined-ranges.tsx
@@ -83,7 +83,7 @@ function usePredefinedDateRanges() {
       label: t`This Year`,
       range: {
         start: now.set({ month: 1, day: 1 }),
-        end: now.set({ month: 12, day: 31 }),
+        end: now, // We want to select this year up to today
       },
     },
     {


### PR DESCRIPTION

## ✨ What has changed?

Enhancements and fixes:

- Set Monday as the first day of the week.
- Hide non-visible month cells to reduce confusion.
- Fix `onChange` prop for `DatePickerRange`.
- Default the focused date to the end date.
- Adjust the predefined `This Year` range to include only dates up to today.


<img width="391" alt="Screenshot 2025-04-02 at 16 26 53" src="https://github.com/user-attachments/assets/d839456e-dc50-413f-a3b3-86dc24c61b3c" />
